### PR TITLE
Create frequency.c from .pyx before building base package

### DIFF
--- a/pipelines/templates/stages/build-python.yaml
+++ b/pipelines/templates/stages/build-python.yaml
@@ -43,6 +43,7 @@ stages:
               # Build base
               cd assemblyline-base
               echo $VERSION > assemblyline/VERSION
+              cythonize -i assemblyline/common/frequency.pyx
               python -m build -s -o ${SYSTEM_DEFAULTWORKINGDIRECTORY}/dist/ &
 
               # Build core


### PR DESCRIPTION
Building using the `build` module doesn't create `assemblyline/common/frequency.c` that using `setuptools` granted us originally before the change to the build pipelines.

The extra line before the build of the base package should ensure that `frequency.c` is included.