### PR TITLE
Update setuptools to the latest version in the root image

### DIFF
--- a/pipelines/ui-config.yaml
+++ b/pipelines/ui-config.yaml
@@ -44,5 +44,11 @@ submission:
           validator_type: keyword
     strict_schemes:
       - strict_ingest
+  profiles:
+    # Profile that will enforce metadata validation
+    - name: "static"
+      display_name: "Static Analysis"
+      params:
+        type: strict_ingest
 ui:
   enforce_quota: false

--- a/root-image/common.Dockerfile
+++ b/root-image/common.Dockerfile
@@ -7,3 +7,6 @@ RUN apt-get update && apt-get -yy upgrade && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
   && apt-get install -yy libffi8 libfuzzy2 libmagic1 git\
   && rm -rf /var/lib/apt/lists/*
+
+# Update setuptools package
+pip install -U setuptools


### PR DESCRIPTION
Related to: https://github.com/advisories/GHSA-cx63-2mw6-8hw5

The Python image we're using comes bundled with `setuptools==65.5.1`
