### PR TITLE
Enable API debugging during build

### DIFF
--- a/pipelines/ui-config.yaml
+++ b/pipelines/ui-config.yaml
@@ -53,4 +53,5 @@ submission:
         services:
           excluded: ["Dynamic Analysis"]
 ui:
+  debug: true
   enforce_quota: false


### PR DESCRIPTION
More useful for us to debug the pipelines, even if the issues are intermittent.