### PR TITLE
Indicate support for version 4.6.x in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,7 @@
 | 4.3.x   | :white_check_mark: |
 | 4.4.x   | :white_check_mark: |
 | 4.5.x   | :white_check_mark: |
+| 4.6.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Based on [CVE-2025-55013](https://github.com/CybercentreCanada/assemblyline/security/advisories/GHSA-75jv-vfxf-3865) and #382 being addressed in 4.6.x, I imagine security support should be reflected in the security.md file. 