### PR TITLE
Add MCP to build release pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = assemblyline-ui-frontend
 	url = https://github.com/CybercentreCanada/assemblyline-ui-frontend.git
 	branch = .
+[submodule "assemblyline-mcp"]
+	path = assemblyline-mcp
+	url = https://github.com/CybercentreCanada/assemblyline-mcp.git
+	branch = .

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -19,12 +19,14 @@ variables:
     VERSION: ${{ variables['TAG'] }}
     BUILD_TYPE: ${{ iif(contains(variables['TAG'], 'stable'), 'stable', 'latest') }}
     SERIES: ${{ format('4.{0}.{1}', split(variables['TAG'], '.')[1], variables['BUILD_TYPE']) }}
+    PUSH_TAGS: true
   ${{ else }}:
     # Default values for non-tag builds
     TAG: "5.0.0.dev0"
     VERSION: "5.0.0.dev0"
-    BUILD_TYPE: "test"
-    SERIES: "5.0.dev"
+    BUILD_TYPE: "latest"
+    SERIES: "5.0.latest"
+    PUSH_TAGS: false
 
 resources:
   containers:
@@ -222,7 +224,7 @@ stages:
   ### PUBLISHING ###
   - stage: deploy
     displayName: Deploy
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    condition: and(succeeded(), variables['PUSH_TAGS'])
     dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, test_mcp]
     jobs:
     - job: deploy_python

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -218,7 +218,7 @@ stages:
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
     - stage: deploy
       displayName: Deploy
-      dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, test_mcp]
+      dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, build_test_mcp]
       jobs:
       - job: deploy_python
         displayName: Deploy Python Packages

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -1,5 +1,6 @@
 
-name: build
+name: ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }} build ${{ else }} test ${{ end }}
+
 
 trigger:
   tags:
@@ -222,246 +223,246 @@ stages:
       dependsOn: [build_v4_service_base]
 
   ### PUBLISHING ###
-  - stage: deploy
-    displayName: Deploy
-    condition: and(succeeded(), variables['PUSH_TAGS'])
-    dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, test_mcp]
-    jobs:
-    - job: deploy_python
-      displayName: Deploy Python Packages
-      dependsOn: []
-      variables:
-        - group: deployment-information
-      steps:
-        - checkout: none
-        - download: current
-          artifact: working
-        - task: UsePythonVersion@0
-          displayName: Set python version
-          inputs:
-            versionSpec: 3.11
-        - script: |
-            set -exv  # Echo commands before they are run
-            sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -U packaging twine
-            ls dist
-            twine upload --skip-existing dist/*
-          workingDirectory: $(Pipeline.Workspace)/working/
-          displayName: Deploy to PyPI
-          retryCountOnTaskFailure: 3
-          env:
-            TWINE_USERNAME: $(twineUsername)
-            TWINE_PASSWORD: $(twinePassword)
-    - job: deploy_containers
-      displayName: Deploy Docker Image
-      dependsOn: []
-      variables:
-        - group: "Dockerhub README"
-      strategy:
-        matrix:
-          Base:
-            CONTAINER_NAME: assemblyline
-            DIRECTORY: assemblyline-base
-          Core:
-            CONTAINER_NAME: assemblyline-core
-          RustCore:
-            CONTAINER_NAME: assemblyline-rust
-          UI:
-            CONTAINER_NAME: assemblyline-ui
-          UI-plugin-lookup-assemblyline:
-            CONTAINER_NAME: assemblyline-ui-plugin-lookup-assemblyline
-            DIRECTORY: assemblyline-ui
-            README_PATH: plugins/external_lookup/assemblyline_lookup/README.md
-          UI-plugin-lookup-malwarebazaar:
-            CONTAINER_NAME: assemblyline-ui-plugin-lookup-malwarebazaar
-            DIRECTORY: assemblyline-ui
-            README_PATH: plugins/external_lookup/malware_bazaar/README.md
-          UI-plugin-lookup-virustotal:
-            CONTAINER_NAME: assemblyline-ui-plugin-lookup-virustotal
-            DIRECTORY: assemblyline-ui
-            README_PATH: plugins/external_lookup/virustotal/README.md
-          UI-frontend:
-            CONTAINER_NAME: assemblyline-ui-frontend
-          MCP:
-            CONTAINER_NAME: assemblyline-mcp
-          SocketIO:
-            CONTAINER_NAME: assemblyline-socketio
-            DIRECTORY: assemblyline-ui
-          Service-Base:
-            CONTAINER_NAME: assemblyline-v4-service-base
-            DIRECTORY: assemblyline-v4-service
-          Sample-Service:
-            CONTAINER_NAME: assemblyline-service-resultsample
-            DIRECTORY: assemblyline-v4-service
-            README_PATH: assemblyline-v4-service/assemblyline_result_sample_service/README.md
-      steps:
-        - checkout: none
-        - task: Docker@2
-          displayName: Login to docker hub
-          inputs:
-            command: login
-            containerRegistry: dockerhub
-        - task: Docker@2
-          displayName: Login to github packages
-          inputs:
-            command: login
-            containerRegistry: github-packages-sa
-        - task: Docker@2
-          displayName: Login to temp registry
-          inputs:
-            command: login
-            containerRegistry: cccstemp
-        - task: Docker@2
-          displayName: Login to chimera
-          inputs:
-            command: login
-            containerRegistry: CHIMERA-U-ACR
-        # Push to container registries
-        - script: |
-            set -exv  # Echo commands before they are run
-            if [[ "$TAG" == *stable* ]]; then export BUILD_TYPE=stable; else export BUILD_TYPE=latest; fi
-            export VERSION=${TAG/stable}
-            export VERSION=${VERSION/beta/b}
-            export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_TYPE}"
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+    - stage: deploy
+      displayName: Deploy
+      dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, test_mcp]
+      jobs:
+      - job: deploy_python
+        displayName: Deploy Python Packages
+        dependsOn: []
+        variables:
+          - group: deployment-information
+        steps:
+          - checkout: none
+          - download: current
+            artifact: working
+          - task: UsePythonVersion@0
+            displayName: Set python version
+            inputs:
+              versionSpec: 3.11
+          - script: |
+              set -exv  # Echo commands before they are run
+              sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -U packaging twine
+              ls dist
+              twine upload --skip-existing dist/*
+            workingDirectory: $(Pipeline.Workspace)/working/
+            displayName: Deploy to PyPI
+            retryCountOnTaskFailure: 3
+            env:
+              TWINE_USERNAME: $(twineUsername)
+              TWINE_PASSWORD: $(twinePassword)
+      - job: deploy_containers
+        displayName: Deploy Docker Image
+        dependsOn: []
+        variables:
+          - group: "Dockerhub README"
+        strategy:
+          matrix:
+            Base:
+              CONTAINER_NAME: assemblyline
+              DIRECTORY: assemblyline-base
+            Core:
+              CONTAINER_NAME: assemblyline-core
+            RustCore:
+              CONTAINER_NAME: assemblyline-rust
+            UI:
+              CONTAINER_NAME: assemblyline-ui
+            UI-plugin-lookup-assemblyline:
+              CONTAINER_NAME: assemblyline-ui-plugin-lookup-assemblyline
+              DIRECTORY: assemblyline-ui
+              README_PATH: plugins/external_lookup/assemblyline_lookup/README.md
+            UI-plugin-lookup-malwarebazaar:
+              CONTAINER_NAME: assemblyline-ui-plugin-lookup-malwarebazaar
+              DIRECTORY: assemblyline-ui
+              README_PATH: plugins/external_lookup/malware_bazaar/README.md
+            UI-plugin-lookup-virustotal:
+              CONTAINER_NAME: assemblyline-ui-plugin-lookup-virustotal
+              DIRECTORY: assemblyline-ui
+              README_PATH: plugins/external_lookup/virustotal/README.md
+            UI-frontend:
+              CONTAINER_NAME: assemblyline-ui-frontend
+            MCP:
+              CONTAINER_NAME: assemblyline-mcp
+            SocketIO:
+              CONTAINER_NAME: assemblyline-socketio
+              DIRECTORY: assemblyline-ui
+            Service-Base:
+              CONTAINER_NAME: assemblyline-v4-service-base
+              DIRECTORY: assemblyline-v4-service
+            Sample-Service:
+              CONTAINER_NAME: assemblyline-service-resultsample
+              DIRECTORY: assemblyline-v4-service
+              README_PATH: assemblyline-v4-service/assemblyline_result_sample_service/README.md
+        steps:
+          - checkout: none
+          - task: Docker@2
+            displayName: Login to docker hub
+            inputs:
+              command: login
+              containerRegistry: dockerhub
+          - task: Docker@2
+            displayName: Login to github packages
+            inputs:
+              command: login
+              containerRegistry: github-packages-sa
+          - task: Docker@2
+            displayName: Login to temp registry
+            inputs:
+              command: login
+              containerRegistry: cccstemp
+          - task: Docker@2
+            displayName: Login to chimera
+            inputs:
+              command: login
+              containerRegistry: CHIMERA-U-ACR
+          # Push to container registries
+          - script: |
+              set -exv  # Echo commands before they are run
+              if [[ "$TAG" == *stable* ]]; then export BUILD_TYPE=stable; else export BUILD_TYPE=latest; fi
+              export VERSION=${TAG/stable}
+              export VERSION=${VERSION/beta/b}
+              export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_TYPE}"
 
-            export BUILT_AS=cccstemp.azurecr.io/${CONTAINER_NAME}:$TAG
-            docker pull $BUILT_AS
+              export BUILT_AS=cccstemp.azurecr.io/${CONTAINER_NAME}:$TAG
+              docker pull $BUILT_AS
 
-            # Publish to public container registries
-            for IMAGE in "cccs/" "ghcr.io/cybercentrecanada/assemblyline/"
-            do
+              # Publish to public container registries
+              for IMAGE in "cccs/" "ghcr.io/cybercentrecanada/assemblyline/"
+              do
+                docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$TAG
+                docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$BUILD_TYPE
+                docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$SERIES
+                docker push ${IMAGE}${CONTAINER_NAME} --all-tags
+              done
+
+              # Publish to private container registry (append labelling)
+              docker build -t $BUILT_AS -<<EOF
+              FROM $BUILT_AS
+              LABEL classification=UNCLASSIFIED
+              EOF
+
+              IMAGE=uchimera.azurecr.io/cccs/
               docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$TAG
               docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$BUILD_TYPE
               docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$SERIES
               docker push ${IMAGE}${CONTAINER_NAME} --all-tags
-            done
 
-            # Publish to private container registry (append labelling)
-            docker build -t $BUILT_AS -<<EOF
-            FROM $BUILT_AS
-            LABEL classification=UNCLASSIFIED
-            EOF
+            displayName: Deploy base Docker Hub
+            retryCountOnTaskFailure: 3
 
-            IMAGE=uchimera.azurecr.io/cccs/
-            docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$TAG
-            docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$BUILD_TYPE
-            docker tag $BUILT_AS ${IMAGE}${CONTAINER_NAME}:$SERIES
-            docker push ${IMAGE}${CONTAINER_NAME} --all-tags
-
-          displayName: Deploy base Docker Hub
-          retryCountOnTaskFailure: 3
-
-        # Publish image documentation to DockerHub
-        - template: templates/steps/publish-description.yaml
-          parameters:
-            dockerhub_repo: $(CONTAINER_NAME)
-            readme_path: $(README_PATH)
+          # Publish image documentation to DockerHub
+          - template: templates/steps/publish-description.yaml
+            parameters:
+              dockerhub_repo: $(CONTAINER_NAME)
+              readme_path: $(README_PATH)
 
 
-    - job: update_helm_release
-      displayName: "Update default release in Helm chart"
-      steps:
-        - checkout: HelmRepo
-          path: assemblyline-helm-chart
-          persistCredentials: true
-        - script: |
-            set -exv  # Echo commands before they are run
+      - job: update_helm_release
+        displayName: "Update default release in Helm chart"
+        steps:
+          - checkout: HelmRepo
+            path: assemblyline-helm-chart
+            persistCredentials: true
+          - script: |
+              set -exv  # Echo commands before they are run
 
-            git fetch --all
-            git checkout main
-            if git show-ref --quiet refs/remotes/origin/dev && [[ "$TAG" == *dev* ]]; then
-              git checkout dev
-            fi
+              git fetch --all
+              git checkout main
+              if git show-ref --quiet refs/remotes/origin/dev && [[ "$TAG" == *dev* ]]; then
+                git checkout dev
+              fi
 
-            export CHART_VERSION=${TAG#"4."}
-            export CHART_VERSION=${CHART_VERSION/stable}
-            export CHART_VERSION=${CHART_VERSION/dev}
-            if [[ "$TAG" == *dev* ]]; then
-              export CHART_VERSION="${CHART_VERSION}-dev"
-            fi
+              export CHART_VERSION=${TAG#"4."}
+              export CHART_VERSION=${CHART_VERSION/stable}
+              export CHART_VERSION=${CHART_VERSION/dev}
+              if [[ "$TAG" == *dev* ]]; then
+                export CHART_VERSION="${CHART_VERSION}-dev"
+              fi
 
-            chmod -R a+rw .
-            sed -i 's/release: .*/release: '"$TAG"'/g' charts/assemblyline/values.yaml
-            sed -i 's/version: .*/version: '"$CHART_VERSION"'/g' charts/assemblyline/Chart.yaml
-            sed -i 's/appVersion: .*/appVersion: "'"$TAG"'"/g' charts/assemblyline/Chart.yaml
-
-            git add .
-            git config --global user.email "assemblyline@cyber.gc.ca"
-            git config --global user.name "Azure Pipeline"
-            git commit -m "Pipeline: Release $TAG"
-
-            git push --force origin HEAD:release
-
-          workingDirectory: $(Pipeline.Workspace)/assemblyline-helm-chart
-          displayName: "Patch the default release version to the latest stable"
-          retryCountOnTaskFailure: 3
-
-    - job: update_docker_release
-      displayName: "Update default release in Docker appliance"
-      steps:
-        - checkout: DockerRepo
-          path: assemblyline-docker-compose
-          persistCredentials: true
-        - script: |
-            set -exv  # Echo commands before they are run
-
-            if [[ "$TAG" == *stable* ]]
-            then
-              git checkout master
               chmod -R a+rw .
-              sed -i 's/AL_VERSION=.*/AL_VERSION='$TAG'/g' .env
+              sed -i 's/release: .*/release: '"$TAG"'/g' charts/assemblyline/values.yaml
+              sed -i 's/version: .*/version: '"$CHART_VERSION"'/g' charts/assemblyline/Chart.yaml
+              sed -i 's/appVersion: .*/appVersion: "'"$TAG"'"/g' charts/assemblyline/Chart.yaml
+
               git add .
               git config --global user.email "assemblyline@cyber.gc.ca"
               git config --global user.name "Azure Pipeline"
               git commit -m "Pipeline: Release $TAG"
-              git push
-            fi
 
-          workingDirectory: $(Pipeline.Workspace)/assemblyline-docker-compose
-          displayName: "Patch the default release version to the latest stable"
-          retryCountOnTaskFailure: 3
+              git push --force origin HEAD:release
 
-    - job: update_odm_docs
-      displayName: "Update Assemblyline4 Documentation"
-      steps:
-        - download: current
-          artifact: working
-        - checkout: DocsRepo
-          path: assemblyline4_docs
-          persistCredentials: true
-        - task: Docker@2
-          displayName: Login to temp registry
-          inputs:
-            command: login
-            containerRegistry: cccstemp
-        - script: |
-            set -exv  # Echo commands before they are run
+            workingDirectory: $(Pipeline.Workspace)/assemblyline-helm-chart
+            displayName: "Patch the default release version to the latest stable"
+            retryCountOnTaskFailure: 3
 
-            if [[ "$TAG" == *stable* ]]
-            then
-              # Prepare output directory
-              cp -rf $(Agent.BuildDirectory)/assemblyline4_docs .
-              (cd assemblyline4_docs && git checkout master)
-              chmod -R a+rw ./assemblyline4_docs
+      - job: update_docker_release
+        displayName: "Update default release in Docker appliance"
+        steps:
+          - checkout: DockerRepo
+            path: assemblyline-docker-compose
+            persistCredentials: true
+          - script: |
+              set -exv  # Echo commands before they are run
 
-              # Generate documentation from script
-              docker run -v $PWD/assemblyline4_docs:/tmp/assemblyline4_docs:rw \
-                        -v $PWD/assemblyline-base:/tmp/assemblyline-base:ro \
-                        -v $PWD/gen_docs.py:/tmp/gen_docs.py:ro \
-                        -w /tmp \
-                        cccstemp.azurecr.io/assemblyline:${TAG} \
-                        /bin/bash -c 'pip install mkdocs-material mkdocs-static-i18n && python gen_docs.py . "/assemblyline4_docs"'
-
-              # Commit documentation changes (if any) to Documentation repo
-              cd assemblyline4_docs
-              if [[ `git status --porcelain` ]]; then
+              if [[ "$TAG" == *stable* ]]
+              then
+                git checkout master
+                chmod -R a+rw .
+                sed -i 's/AL_VERSION=.*/AL_VERSION='$TAG'/g' .env
                 git add .
                 git config --global user.email "assemblyline@cyber.gc.ca"
                 git config --global user.name "Azure Pipeline"
-                git commit -m "Pipeline: Release $TAG documentation"
+                git commit -m "Pipeline: Release $TAG"
                 git push
               fi
-            fi
 
-          workingDirectory: $(Pipeline.Workspace)/working/
-          displayName: "Run script to generate documentation and commit changes"
-          retryCountOnTaskFailure: 3
+            workingDirectory: $(Pipeline.Workspace)/assemblyline-docker-compose
+            displayName: "Patch the default release version to the latest stable"
+            retryCountOnTaskFailure: 3
+
+      - job: update_odm_docs
+        displayName: "Update Assemblyline4 Documentation"
+        steps:
+          - download: current
+            artifact: working
+          - checkout: DocsRepo
+            path: assemblyline4_docs
+            persistCredentials: true
+          - task: Docker@2
+            displayName: Login to temp registry
+            inputs:
+              command: login
+              containerRegistry: cccstemp
+          - script: |
+              set -exv  # Echo commands before they are run
+
+              if [[ "$TAG" == *stable* ]]
+              then
+                # Prepare output directory
+                cp -rf $(Agent.BuildDirectory)/assemblyline4_docs .
+                (cd assemblyline4_docs && git checkout master)
+                chmod -R a+rw ./assemblyline4_docs
+
+                # Generate documentation from script
+                docker run -v $PWD/assemblyline4_docs:/tmp/assemblyline4_docs:rw \
+                          -v $PWD/assemblyline-base:/tmp/assemblyline-base:ro \
+                          -v $PWD/gen_docs.py:/tmp/gen_docs.py:ro \
+                          -w /tmp \
+                          cccstemp.azurecr.io/assemblyline:${TAG} \
+                          /bin/bash -c 'pip install mkdocs-material mkdocs-static-i18n && python gen_docs.py . "/assemblyline4_docs"'
+
+                # Commit documentation changes (if any) to Documentation repo
+                cd assemblyline4_docs
+                if [[ `git status --porcelain` ]]; then
+                  git add .
+                  git config --global user.email "assemblyline@cyber.gc.ca"
+                  git config --global user.name "Azure Pipeline"
+                  git commit -m "Pipeline: Release $TAG documentation"
+                  git push
+                fi
+              fi
+
+            workingDirectory: $(Pipeline.Workspace)/working/
+            displayName: "Run script to generate documentation and commit changes"
+            retryCountOnTaskFailure: 3

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -132,6 +132,15 @@ stages:
       dockerFile: docker/ui/Dockerfile
       imageName: assemblyline-ui
 
+  # MCP
+  - template: templates/stages/build-container.yaml
+    parameters:
+      baseImage: astral/uv:python3.14-alpine # This is ignore by the Dockerfile
+      component: assemblyline-mcp
+      dependsOn: []                          # Standalone component, no Assemblyline dependencies for build
+      dockerFile: Dockerfile
+      imageName: assemblyline-mcp
+
   # SocketIO
   - template: templates/stages/build-container.yaml
     parameters:
@@ -186,6 +195,8 @@ stages:
 
   - template: templates/stages/test-ui.yaml
 
+  - template: templates/stages/test-mcp.yaml
+
   - template: templates/stages/test-e2e.yaml
 
   - template: templates/stages/test-container.yaml
@@ -197,7 +208,7 @@ stages:
   ### PUBLISHING ###
   - stage: deploy
     displayName: Deploy
-    dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust]
+    dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, test_mcp]
     jobs:
     - job: deploy_python
       displayName: Deploy Python Packages
@@ -253,6 +264,8 @@ stages:
             README_PATH: plugins/external_lookup/virustotal/README.md
           UI-frontend:
             CONTAINER_NAME: assemblyline-ui-frontend
+          MCP:
+            CONTAINER_NAME: assemblyline-mcp
           SocketIO:
             CONTAINER_NAME: assemblyline-socketio
             DIRECTORY: assemblyline-ui

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -17,7 +17,7 @@ variables:
     # Set variables for tag builds
     TAG: ${{ replace(variables['Build.SourceBranch'], 'refs/tags/v', '') }}
     VERSION: ${{ variables['TAG'] }}
-    BUILD_TYPE: ${{ if contains(variables['TAG'], 'stable') }}stable${{ else }}latest${{ end }}
+    BUILD_TYPE: ${{ iif(contains(variables['TAG'], 'stable'), 'stable', 'latest') }}
     SERIES: ${{ format('4.{0}.{1}', split(variables['TAG'], '.')[1], variables['BUILD_TYPE']) }}
   ${{ else }}:
     # Default values for non-tag builds

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -4,13 +4,27 @@ name: build
 trigger:
   tags:
     include: ["v*"]
+  branches:
+    exclude:
+      - "main"    
 pr: none
 
 pool:
   vmImage: "ubuntu-latest"
 
 variables:
-  TAG: ${{ replace(variables['Build.SourceBranch'], 'refs/tags/v', '') }}
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+    # Set variables for tag builds
+    TAG: ${{ replace(variables['Build.SourceBranch'], 'refs/tags/v', '') }}
+    VERSION: ${{ variables['TAG'] }}
+    BUILD_TYPE: ${{ if contains(variables['TAG'], 'stable') }}stable${{ else }}latest${{ end }}
+    SERIES: ${{ format('4.{0}.{1}', split(variables['TAG'], '.')[1], variables['BUILD_TYPE']) }}
+  ${{ else }}:
+    # Default values for non-tag builds
+    TAG: "5.0.0.dev0"
+    VERSION: "5.0.0.dev0"
+    BUILD_TYPE: "test"
+    SERIES: "5.0.dev"
 
 resources:
   containers:
@@ -208,6 +222,7 @@ stages:
   ### PUBLISHING ###
   - stage: deploy
     displayName: Deploy
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
     dependsOn: [test_assemblyline, test_core, test_ui, build_frontend, test_v4_service_base, test_rust, build_rust, test_mcp]
     jobs:
     - job: deploy_python

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -1,5 +1,5 @@
 
-name: ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }} build ${{ else }} test ${{ end }}
+name: ${{ iif(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), 'build', 'test') }}
 
 
 trigger:

--- a/pipelines/full-build.yaml
+++ b/pipelines/full-build.yaml
@@ -110,6 +110,9 @@ stages:
   # Build/Test Frontend
   - template: templates/stages/build-test-frontend.yaml
 
+  # Build/Test MCP
+  - template: templates/stages/build-test-mcp.yaml
+
   # Build Base
   - template: templates/stages/build-base.yaml
 
@@ -148,15 +151,6 @@ stages:
       dependsOn: ["build_base"]
       dockerFile: docker/ui/Dockerfile
       imageName: assemblyline-ui
-
-  # MCP
-  - template: templates/stages/build-container.yaml
-    parameters:
-      baseImage: astral/uv:python3.14-alpine # This is ignore by the Dockerfile
-      component: assemblyline-mcp
-      dependsOn: []                          # Standalone component, no Assemblyline dependencies for build
-      dockerFile: Dockerfile
-      imageName: assemblyline-mcp
 
   # SocketIO
   - template: templates/stages/build-container.yaml
@@ -210,9 +204,7 @@ stages:
       component: assemblyline-core
       dependsOn: [build_core]
 
-  - template: templates/stages/test-ui.yaml
-
-  - template: templates/stages/test-mcp.yaml
+  - template: templates/stages/test-ui.yaml  
 
   - template: templates/stages/test-e2e.yaml
 

--- a/pipelines/templates/jobs/build-container.yaml
+++ b/pipelines/templates/jobs/build-container.yaml
@@ -38,11 +38,6 @@ jobs:
           containerRegistry: cccstemp
       - script: |
           set -exv  # Echo commands before they are run
-          if [[ "$TAG" == *stable* ]]; then export BUILD_KIND=stable; else export BUILD_KIND=latest; fi
-          export VERSION=${TAG/stable}
-          export VERSION=${VERSION/beta/b}
-          export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_KIND}"
-
           if [[ "${{ parameters.workingDirectory }}" = *${{ parameters.component }} ]]
           then
             mv ../dist/ dist
@@ -53,8 +48,8 @@ jobs:
 
           docker build --build-arg base=$BASE \
                         --build-arg version=$VERSION \
-                        --build-arg branch=$BUILD_KIND \
-                        -t $IMAGE:$TAG -t $IMAGE:$BUILD_KIND -t $IMAGE:$SERIES \
+                        --build-arg branch=$BUILD_TYPE \
+                        -t $IMAGE:$TAG -t $IMAGE:$BUILD_TYPE -t $IMAGE:$SERIES \
                         -f ${{ parameters.dockerFile }} ${{ parameters.buildContext }}
           docker push $IMAGE -q --all-tags
         workingDirectory: ${{ parameters.workingDirectory }}

--- a/pipelines/templates/stages/build-base.yaml
+++ b/pipelines/templates/stages/build-base.yaml
@@ -16,27 +16,22 @@ stages:
               containerRegistry: cccstemp
           - script: |
               set -exv  # Echo commands before they are run
-              if [[ "$TAG" == *stable* ]]; then export BUILD_KIND=stable; else export BUILD_KIND=latest; fi
-              export VERSION=${TAG/stable}
-              export VERSION=${VERSION/beta/b}
-              export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_KIND}"
-
               cd assemblyline-base
               mv ../dist/ dist
 
-              docker pull cccstemp.azurecr.io/assemblyline-root-build:$BUILD_KIND &
-              docker pull cccstemp.azurecr.io/assemblyline-root:$BUILD_KIND &
+              docker pull cccstemp.azurecr.io/assemblyline-root-build:$BUILD_TYPE &
+              docker pull cccstemp.azurecr.io/assemblyline-root:$BUILD_TYPE &
               wait
 
               set +xv
               export IMAGE=cccstemp.azurecr.io/assemblyline
-              # docker build --build-arg version=$VERSION -t $IMAGE:$TAG -t $IMAGE:$BUILD_KIND -t $IMAGE:$SERIES . | while read line ; do echo "$(date) | $line"; done;
+              # docker build --build-arg version=$VERSION -t $IMAGE:$TAG -t $IMAGE:$BUILD_TYPE -t $IMAGE:$SERIES . | while read line ; do echo "$(date) | $line"; done;
               docker build --build-arg version=$VERSION \
                            --build-arg version_tag=$TAG \
-                           --build-arg build_image=cccstemp.azurecr.io/assemblyline-root-build:$BUILD_KIND \
+                           --build-arg build_image=cccstemp.azurecr.io/assemblyline-root-build:$BUILD_TYPE \
                            --build-arg base=cccstemp.azurecr.io/assemblyline-root \
-                           --build-arg tag=$BUILD_KIND \
-                           -t $IMAGE:$TAG -t $IMAGE:$BUILD_KIND -t $IMAGE:$SERIES . -f incremental.Dockerfile | while read line ; do echo "$(date) | $line"; done;
+                           --build-arg tag=$BUILD_TYPE \
+                           -t $IMAGE:$TAG -t $IMAGE:$BUILD_TYPE -t $IMAGE:$SERIES . -f incremental.Dockerfile | while read line ; do echo "$(date) | $line"; done;
               docker push $IMAGE -q --all-tags
             workingDirectory: $(Pipeline.Workspace)/working
             displayName: Build Base

--- a/pipelines/templates/stages/build-python.yaml
+++ b/pipelines/templates/stages/build-python.yaml
@@ -34,7 +34,7 @@ stages:
               git config --global http.extraheader "`git config --get http.https://github.com/CybercentreCanada/assemblyline.extraheader`"
               git submodule foreach git checkout -B $BRANCH --track origin/$BRANCH
               git submodule foreach git pull
-              if [[ "$BUILD_TYPE" != "test" ]];
+              if [[ "${PUSH_TAGS,,}" == "true" ]];
               then
                 # Tag all submodules with the same tag as the main repo
                 git submodule foreach git tag ${TAG}

--- a/pipelines/templates/stages/build-python.yaml
+++ b/pipelines/templates/stages/build-python.yaml
@@ -16,8 +16,6 @@ stages:
               set -ex  # Echo commands before they are run
 
               # Figure out what the build kind is
-              export TAG=${BUILD_SOURCEBRANCH#"refs/tags/"}
-              export VERSION=${BUILD_SOURCEBRANCH#"refs/tags/v"}
               if [[ "$VERSION" == *stable* ]];
               then
                 export BRANCH=master;
@@ -36,8 +34,12 @@ stages:
               git config --global http.extraheader "`git config --get http.https://github.com/CybercentreCanada/assemblyline.extraheader`"
               git submodule foreach git checkout -B $BRANCH --track origin/$BRANCH
               git submodule foreach git pull
-              git submodule foreach git tag ${TAG}
-              git submodule foreach git push origin ${TAG}
+              if [[ "$BUILD_TYPE" != "test" ]];
+              then
+                # Tag all submodules with the same tag as the main repo
+                git submodule foreach git tag ${TAG}
+                git submodule foreach git push origin ${TAG}
+              fi
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -U wheel pip build
 
               # Build base

--- a/pipelines/templates/stages/build-rust.yaml
+++ b/pipelines/templates/stages/build-rust.yaml
@@ -16,20 +16,16 @@ stages:
               containerRegistry: cccstemp
           - script: |
               set -exv  # Echo commands before they are run
-              if [[ "$TAG" == *stable* ]]; then export BUILD_KIND=stable; else export BUILD_KIND=latest; fi
-              export VERSION=${TAG/stable}
-              export VERSION=${VERSION/beta/b}
-              export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_KIND}"
 
               set +xv
               docker pull cccstemp.azurecr.io/assemblyline-rust-builder:latest
               export IMAGE=cccstemp.azurecr.io/assemblyline-rust
               docker build --build-arg version=$VERSION \
                            --build-arg version_tag=$TAG \
-                           --build-arg tag=$BUILD_KIND \
+                           --build-arg tag=$BUILD_TYPE \
                            --build-arg build_image=cccstemp.azurecr.io/assemblyline-rust-builder:latest \
                            -t $IMAGE:$TAG \
-                           -t $IMAGE:$BUILD_KIND \
+                           -t $IMAGE:$BUILD_TYPE \
                            -t $IMAGE:$SERIES . -f ./assemblyline-server/Dockerfile | while read line ; do echo "$(date) | $line"; done;
               docker push $IMAGE -q --all-tags
             workingDirectory: $(Pipeline.Workspace)/assemblyline-rust

--- a/pipelines/templates/stages/build-test-frontend.yaml
+++ b/pipelines/templates/stages/build-test-frontend.yaml
@@ -59,11 +59,6 @@ stages:
 
           - script: |
               set -exv
-              if [[ "$TAG" == *stable* ]]; then export BUILD_TYPE=stable; else export BUILD_TYPE=latest; fi
-              export VERSION=${TAG/stable}
-              export VERSION=${VERSION/beta/b}
-              export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_TYPE}"
-
               export IMAGE=cccstemp.azurecr.io/assemblyline-ui-frontend
 
               docker build \

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -78,6 +78,8 @@ stages:
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
 
               # Run MCP tests
+              mkdir -p /etc/assemblyline
+              cp $(Pipeline.Workspace)/working/pipelines/ui-config.yaml /etc/assemblyline/config.yml
               pytest -rsx -vv
 
               # Push images to registry if tests pass

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -81,7 +81,7 @@ stages:
                 -v `pwd`:/test:ro \
                 -w /test \
                 cccstemp.azurecr.io/assemblyline-ui:$TAG \
-                /bin/bash -c "pip install .[test]; CI=1 pytest -rsx --durations=10"
+                /bin/bash -c "pip install .[test] --only-deps; CI=1 pytest -rsx --durations=10"
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -70,9 +70,6 @@ stages:
                 cccs/nginx-ssl-frontend:dev &
               wait
 
-
-              wget https://localhost/mcp/ --no-check-certificate --timeout=2 --retry-on-http-error=502 --waitretry=10 --retry-connrefused
-
               # Install MCP test dependencies
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
 

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -19,6 +19,10 @@ stages:
             inputs:
               command: login
               containerRegistry: cccstemp
+          - task: UsePythonVersion@0
+            displayName: Set python version
+            inputs:
+              versionSpec: 3.14
           - script: |
               set -e
 
@@ -70,14 +74,15 @@ stages:
                 cccs/nginx-ssl-frontend:dev &
               wait
 
-              # Run MCP tests
-              docker run --name test \
-                --network host \
-                -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml:ro \
-                -v `pwd`:/test:ro \
-                -w /test \
-                cccstemp.azurecr.io/assemblyline-ui:$TAG \
-                /bin/bash -c "pip install .[test] --only-deps; CI=1 pytest -rsx --durations=10"
+              # Install MCP test dependencies
+              sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
+
+              # Setup config for MCP tests
+              sudo mkdir -p /etc/assemblyline
+              sudo cp $(Pipeline.Workspace)/working/pipelines/ui-config.yaml /etc/assemblyline/config.yml
+
+              # Run tests
+              CI=1 pytest -rsx --durations=10
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -84,7 +84,7 @@ stages:
                 -v `pwd`:/test \
                 -w /test \
                 cccstemp.azurecr.io/assemblyline-ui:$TAG \
-                /bin/bash -c "pip install -e .[test]; CI=1 pytest -rsx --durations=10"
+                /bin/bash -c "pip install .[test]; CI=1 pytest -rsx --durations=10"
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -1,15 +1,15 @@
 stages:
-  - stage: test_mcp
-    displayName: Test MCP
-    dependsOn: [build_ui, build_mcp]
+  - stage: build_test_mcp
+    displayName: Build & Test MCP
+    dependsOn: [build_ui]
     jobs:
-      - job: test_mcp
+      - job: build_test_mcp
         timeoutInMinutes: 10
         services:
           elasticsearch: elasticsearch
           redis: redis
           minio: minio
-        displayName: Test MCP Image
+        displayName: Build & Test MCP Image
         steps:
           - checkout: none
           - download: current
@@ -21,6 +21,14 @@ stages:
               containerRegistry: cccstemp
           - script: |
               set -e
+
+              # Build MCP image
+              export IMAGE=cccstemp.azurecr.io/assemblyline-mcp
+              docker build --build-arg base=$BASE \
+                            --build-arg version=$VERSION \
+                            --build-arg branch=$BUILD_TYPE \
+                            -t $IMAGE:$TAG -t $IMAGE:$BUILD_TYPE -t $IMAGE:$SERIES \
+                            .
 
               # Start up a KeyCloak instance for OAuth testing
               docker run -d --name keycloak \
@@ -46,9 +54,9 @@ stages:
                 --health-retries=3 \
                 --health-start-period=10s \
                 cccstemp.azurecr.io/assemblyline-ui:$TAG &
-
+              
               # Start MCP
-              docker run -d --name mcp --network host --restart on-failure cccstemp.azurecr.io/assemblyline-mcp:$TAG &
+              docker run -d --name mcp --network host --restart on-failure $IMAGE:$TAG &
 
               # Start Ingress for routing
               docker run -d --name nginx \
@@ -69,6 +77,9 @@ stages:
 
               # Run MCP tests
               pytest -rsx -vv
+
+              # Push images to registry if tests pass
+              docker push $IMAGE -q --all-tags
 
             workingDirectory: $(Pipeline.Workspace)/working/assemblyline-mcp
             displayName: Test MCP

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -81,11 +81,10 @@ stages:
               docker run --name test \
                 --network host \
                 -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml \
-                -v `pwd`/test:/test \
+                -v `pwd`:/test \
                 -w /test \
-                -v `pwd`/pyproject.toml:/opt/pyproject.toml \
                 cccstemp.azurecr.io/assemblyline-ui:$TAG \
-                /bin/bash -c "pip install -e /opt/pyproject.toml[test]; CI=1 pytest -rsx --durations=10"
+                /bin/bash -c "pip install -e .[test]; CI=1 pytest -rsx --durations=10"
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -72,21 +72,18 @@ stages:
                 -e "MCP_HOST=127.0.0.1" \
                 -e "ACCESS_LOG=/dev/stdout" \
                 -e "ERROR_LEVEL=info" \
-                cccs/nginx-ssl-frontend:dev &
+                cccs/nginx-ssl-frontend &
               wait
 
               # Install MCP test dependencies
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
 
-              # Install Pytest-timeout for test timeouts
-              sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir pytest-timeout
-
               # Setup config for MCP tests
               sudo mkdir -p /etc/assemblyline
               sudo cp $(Pipeline.Workspace)/working/pipelines/ui-config.yaml /etc/assemblyline/config.yml
 
-              # Run tests (actual runtime should take 60s or less)
-              PYTEST_TIMEOUT=60 CI=1 pytest -vv -rsx --durations=10
+              # Run tests
+              CI=1 pytest -vv -rsx --durations=10
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -78,9 +78,14 @@ stages:
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
 
               # Run MCP tests
-              mkdir -p /etc/assemblyline
-              cp $(Pipeline.Workspace)/working/pipelines/ui-config.yaml /etc/assemblyline/config.yml
-              pytest -rsx -vv
+              docker run --name test \
+                --network host \
+                -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml \
+                -v `pwd`/test:/test \
+                -w /test \
+                -v `pwd`/pyproject.toml:/opt/pyproject.toml \
+                cccstemp.azurecr.io/assemblyline-ui:$TAG \
+                /bin/bash -c "pip install -e /opt/pyproject.toml[test]; CI=1 pytest -rsx --durations=10"
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -74,14 +74,11 @@ stages:
                 cccs/nginx-ssl-frontend:dev &
               wait
 
-              # Install MCP test dependencies
-              sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
-
               # Run MCP tests
               docker run --name test \
                 --network host \
-                -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml \
-                -v `pwd`:/test \
+                -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml:ro \
+                -v `pwd`:/test:ro \
                 -w /test \
                 cccstemp.azurecr.io/assemblyline-ui:$TAG \
                 /bin/bash -c "pip install .[test]; CI=1 pytest -rsx --durations=10"

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -53,6 +53,7 @@ stages:
                 --health-timeout=30s \
                 --health-retries=3 \
                 --health-start-period=10s \
+                --add-host=localhost:host-gateway \
                 cccstemp.azurecr.io/assemblyline-ui:$TAG &
               
               # Start MCP
@@ -66,7 +67,7 @@ stages:
                 -e "MCP_HOST=127.0.0.1" \
                 -e "ACCESS_LOG=/dev/stdout" \
                 -e "ERROR_LEVEL=info" \
-                cccs/nginx-ssl-frontend &
+                cccs/nginx-ssl-frontend:dev &
               wait
 
 

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -71,7 +71,7 @@ stages:
               wait
 
 
-              wget https://localhost/mcp --no-check-certificate --timeout=2 --retry-on-http-error=502 --waitretry=10 --retry-connrefused
+              wget https://localhost/mcp/ --no-check-certificate --timeout=2 --retry-on-http-error=502 --waitretry=10 --retry-connrefused
 
               # Install MCP test dependencies
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -19,10 +19,6 @@ stages:
             inputs:
               command: login
               containerRegistry: cccstemp
-          - task: UsePythonVersion@0
-            displayName: Set python version
-            inputs:
-              versionSpec: 3.14
           - script: |
               set -e
 

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -19,6 +19,10 @@ stages:
             inputs:
               command: login
               containerRegistry: cccstemp
+          - task: UsePythonVersion@0
+            displayName: Set python version
+            inputs:
+              versionSpec: 3.14
           - script: |
               set -e
 

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -49,6 +49,7 @@ stages:
               # Start UI
               docker run -d --name ui \
                 --network host \
+                -e AL_UNSECURED_UI=true \
                 -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml \
                 -v $(Pipeline.Workspace)/working/pipelines/classification.yaml:/etc/assemblyline/classification.yml \
                 --restart on-failure \

--- a/pipelines/templates/stages/build-test-mcp.yaml
+++ b/pipelines/templates/stages/build-test-mcp.yaml
@@ -77,12 +77,15 @@ stages:
               # Install MCP test dependencies
               sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
 
+              # Install Pytest-timeout for test timeouts
+              sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir pytest-timeout
+
               # Setup config for MCP tests
               sudo mkdir -p /etc/assemblyline
               sudo cp $(Pipeline.Workspace)/working/pipelines/ui-config.yaml /etc/assemblyline/config.yml
 
-              # Run tests
-              CI=1 pytest -rsx --durations=10
+              # Run tests (actual runtime should take 60s or less)
+              PYTEST_TIMEOUT=60 CI=1 pytest -vv -rsx --durations=10
 
               # Push images to registry if tests pass
               docker push $IMAGE -q --all-tags

--- a/pipelines/templates/stages/test-mcp.yaml
+++ b/pipelines/templates/stages/test-mcp.yaml
@@ -1,0 +1,83 @@
+stages:
+  - stage: test_mcp
+    displayName: Test MCP
+    dependsOn: [build_ui, build_mcp]
+    jobs:
+      - job: test_mcp
+        timeoutInMinutes: 10
+        services:
+          elasticsearch: elasticsearch
+          redis: redis
+          minio: minio
+        displayName: Test MCP Image
+        steps:
+          - checkout: none
+          - download: current
+            artifact: working
+          - task: Docker@2
+            displayName: Login to docker registry
+            inputs:
+              command: login
+              containerRegistry: cccstemp
+          - script: |
+              set -e
+
+              # Start up a KeyCloak instance for OAuth testing
+              docker run -d --name keycloak \
+                -e KC_HEALTH_ENABLED=true \
+                -v "$(Pipeline.Workspace)/working/pipelines/keycloak-realm.json:/opt/keycloak/data/import/realm.json:ro" \
+                -p 8080:8080 \
+                --health-cmd="bash -c \"{ printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000\"" \
+                --health-interval=5s \
+                --health-timeout=5s \
+                --health-retries=3 \
+                --health-start-period=10s \
+                quay.io/keycloak/keycloak:26.7 start-dev --import-realm
+
+              # Start UI
+              docker run -d --name ui \
+                --network host \
+                -v $(Pipeline.Workspace)/working/pipelines/ui-config.yaml:/etc/assemblyline/config.yml \
+                -v $(Pipeline.Workspace)/working/pipelines/classification.yaml:/etc/assemblyline/classification.yml \
+                --restart on-failure \
+                --health-cmd="bash -c \"python -c 'import requests; requests.head(\"http://localhost:5000/healthz/live\", timeout=2).raise_for_status()' || exit 1\"" \
+                --health-interval=30s \
+                --health-timeout=30s \
+                --health-retries=3 \
+                --health-start-period=10s \
+                cccstemp.azurecr.io/assemblyline-ui:$TAG &
+
+              # Start MCP
+              docker run -d --name mcp --network host --restart on-failure cccstemp.azurecr.io/assemblyline-mcp:$TAG &
+
+              # Start Ingress for routing
+              docker run -d --name nginx \
+                --network host \
+                --restart on-failure \
+                -e "UI_HOST=127.0.0.1" \
+                -e "MCP_HOST=127.0.0.1" \
+                -e "ACCESS_LOG=/dev/stdout" \
+                -e "ERROR_LEVEL=info" \
+                cccs/nginx-ssl-frontend &
+              wait
+
+
+              wget https://localhost/mcp --no-check-certificate --timeout=2 --retry-on-http-error=502 --waitretry=10 --retry-connrefused
+
+              # Install MCP test dependencies
+              sudo env "PATH=$PATH" "PIP_USE_PEP517=true" python -m pip install --no-cache-dir -e .[test]
+
+              # Run MCP tests
+              pytest -rsx -vv
+
+            workingDirectory: $(Pipeline.Workspace)/working/assemblyline-mcp
+            displayName: Test MCP
+          - script: docker logs ui
+            condition: failed()
+            displayName: UI Logs
+          - script: docker logs mcp
+            condition: failed()
+            displayName: MCP Logs
+          - script: docker logs nginx
+            condition: failed()
+            displayName: NGINX Logs

--- a/pipelines/templates/stages/test-rust.yaml
+++ b/pipelines/templates/stages/test-rust.yaml
@@ -13,8 +13,6 @@ stages:
           - script: |
               set -e
               # Figure out what the build kind is
-              export TAG=${BUILD_SOURCEBRANCH#"refs/tags/"}
-              export VERSION=${BUILD_SOURCEBRANCH#"refs/tags/v"}
               if [[ "$VERSION" == *stable* ]];
               then
                 export BRANCH=main;
@@ -31,8 +29,12 @@ stages:
 
               git fetch origin ${BRANCH}
               git checkout ${BRANCH}
-              git tag ${TAG}
-              git push origin ${TAG}
+              if [[ "$BUILD_TYPE" != "test" ]];
+              then
+                # Tag the source with the same tag as the main repo
+                git tag ${TAG}
+                git push origin ${TAG}
+              fi
 
             workingDirectory: $(Pipeline.Workspace)/assemblyline-rust
             displayName: Tag Source

--- a/pipelines/templates/stages/test-rust.yaml
+++ b/pipelines/templates/stages/test-rust.yaml
@@ -29,7 +29,7 @@ stages:
 
               git fetch origin ${BRANCH}
               git checkout ${BRANCH}
-              if [[ "$BUILD_TYPE" != "test" ]];
+              if [[ "${PUSH_TAGS,,}" == "true" ]];
               then
                 # Tag the source with the same tag as the main repo
                 git tag ${TAG}


### PR DESCRIPTION
- Add MCP server to build pipeline for release
- Add commit-based testing so we can evaluate pipeline changes without triggering a release